### PR TITLE
Using default parser should work on later rails versions

### DIFF
--- a/lib/google_cse.rb
+++ b/lib/google_cse.rb
@@ -23,7 +23,7 @@ module GoogleCustomSearch
     # Get and parse results.
     url = url(query, start)
     json = fetch_json(url)
-    data = Crack::JSON.parse(json)
+    data = JSON.parse(json)
 
     # Extract and return pages data and search result data.
     if data['responseData']


### PR DESCRIPTION
Crack is no longer a good gem after Ruby 1.9.\* and I believe that JSON operation should be directly suported, at least on Rails 4. It may need the "require 'json'" on 3\* and I have no idea if it works on 2.*, so I'll leave it up to you.

If you want, I can do some tests on my spare time!

Thanks and good job with the gem! :+1: 
